### PR TITLE
Remove uses of GLib deprecated features

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AX_CHECK_GUILE([2.0.0])
 
 PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.20.0], ,
   AC_MSG_ERROR([GLib 2.20.0 or later is required.]))
+AC_DEFINE([G_DISABLE_DEPRECATED], [1], [Disable deprecated GLib features])
 
 PKG_CHECK_MODULES(GIO, [gio-2.0 >= 2.20.0], ,
   AC_MSG_ERROR([GIO 2.20.0 or later is required.]))

--- a/libgeda/src/f_basic.c
+++ b/libgeda/src/f_basic.c
@@ -220,7 +220,7 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
 
   /* Before we open the page, let's load the corresponding gafrc. */
   /* First cd into file's directory. */
-  file_directory = g_dirname (full_filename);
+  file_directory = g_path_get_dirname (full_filename);
 
   if (file_directory) { 
     if (chdir (file_directory)) {

--- a/libgeda/src/geda_page.c
+++ b/libgeda/src/geda_page.c
@@ -380,7 +380,7 @@ void s_page_goto (TOPLEVEL *toplevel, PAGE *p_new)
 
   s_toplevel_set_page_current (toplevel, p_new);
 
-  dirname = g_dirname (p_new->page_filename);
+  dirname = g_path_get_dirname (p_new->page_filename);
   if (chdir (dirname)) {
     /* An error occured with chdir */
 #warning FIXME: What do we do?


### PR DESCRIPTION
This patch removes the final uses of deprecated GLib functions. It also updates the build configuration to disable deprecated GLib functions at compile time.