### PR TITLE
build: Enable Automake silent build rules by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADER([config.h])
 
 AM_INIT_AUTOMAKE([parallel-tests color-tests])
-AM_SILENT_RULES
+AM_SILENT_RULES([yes])
 
 AC_GNU_SOURCE # FIXME for some reason this is needed?
 

--- a/gaf/Makefile.am
+++ b/gaf/Makefile.am
@@ -43,7 +43,7 @@ DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@
 snarf_cpp_opts = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(gaf_CPPFLAGS) $(AM_CFLAGS) $(gaf_CFLAGS)
 .c.x:
-	CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
+	$(AM_V_GEN) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
 
 .1.in.1:
 	d=`$(GUILE) -c '(setlocale LC_ALL "C") \

--- a/gnetlist/src/Makefile.am
+++ b/gnetlist/src/Makefile.am
@@ -39,7 +39,7 @@ SUFFIXES = .x
 snarf_cpp_opts = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(gnetlist_CPPFLAGS) $(AM_CFLAGS) $(gnetlist_CFLAGS)
 .c.x:
-	CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
+	$(AM_V_GEN) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
 
 MOSTLYCLEANFILES = *.log *.ps core FILE *~
 CLEANFILES = *.log *.ps core FILE *~ $(BUILT_SOURCES)

--- a/gschem/src/Makefile.am
+++ b/gschem/src/Makefile.am
@@ -135,7 +135,7 @@ SUFFIXES = .x
 snarf_cpp_opts = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(gschem_CPPFLAGS) $(AM_CFLAGS) $(gschem_CFLAGS)
 .c.x:
-	CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
+	$(AM_V_GEN) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
 
 localedir = @datadir@/locale
 DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@

--- a/libgeda/src/Makefile.am
+++ b/libgeda/src/Makefile.am
@@ -110,7 +110,7 @@ SUFFIXES = .x
 snarf_cpp_opts = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(libgeda_la_CPPFLAGS) $(AM_CFLAGS) $(libgeda_la_CFLAGS)
 .c.x:
-	CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
+	$(AM_V_GEN) CPP="$(CPP)" $(GUILE_SNARF) -o $@ $< $(snarf_cpp_opts)
 
 MOSTLYCLEANFILES = *.log core FILE *~
 CLEANFILES = *.log core FILE *~ $(BUILT_SOURCES)


### PR DESCRIPTION
This greatly reduces the size of the geda-gaf build log, and makes
compilation warnings and errors stand out much better.