### PR TITLE
Fix issues related to Scheme value handling

### DIFF
--- a/gschem/src/g_attrib.c
+++ b/gschem/src/g_attrib.c
@@ -103,9 +103,9 @@ SCM_DEFINE (add_attrib_x, "%add-attrib!", 5, 0, 0,
 
   /* Name/value visibility */
   int show;
-  if      (show_s == name_sym)  { show = SHOW_NAME;       }
-  else if (show_s == value_sym) { show = SHOW_VALUE;      }
-  else if (show_s == both_sym)  { show = SHOW_NAME_VALUE; }
+  if      (scm_is_eq (show_s, name_sym))  { show = SHOW_NAME;       }
+  else if (scm_is_eq (show_s, value_sym)) { show = SHOW_VALUE;      }
+  else if (scm_is_eq (show_s, both_sym))  { show = SHOW_NAME_VALUE; }
   else {
     scm_misc_error (s_add_attrib_x,
                     _("Invalid text name/value visibility ~A."),

--- a/gschem/src/g_rc.c
+++ b/gschem/src/g_rc.c
@@ -98,7 +98,7 @@ SCM g_rc_gschem_version(SCM scm_version)
 		      g_utf8_casefold (PACKAGE_DATE_VERSION,-1)) != 0) {
     sourcefile = NULL;
     rc_filename = g_rc_rc_filename ();
-    if (rc_filename == SCM_BOOL_F) {
+    if (scm_is_false (rc_filename)) {
       rc_filename = scm_from_utf8_string ("unknown");
     }
     sourcefile = scm_to_utf8_string (rc_filename);
@@ -1180,7 +1180,7 @@ extern GedaColorMap display_outline_colors;
 
 SCM g_rc_display_color_map (SCM scm_map)
 {
-  if (scm_map == SCM_UNDEFINED) {
+  if (scm_is_eq (scm_map, SCM_UNDEFINED)) {
     return s_color_map_to_scm (display_colors);
   }
 
@@ -1193,7 +1193,7 @@ SCM g_rc_display_color_map (SCM scm_map)
 
 SCM g_rc_display_outline_color_map (SCM scm_map)
 {
-  if (scm_map == SCM_UNDEFINED) {
+  if (scm_is_eq (scm_map, SCM_UNDEFINED)) {
     return s_color_map_to_scm (display_outline_colors);
   }
 

--- a/gschem/src/g_window.c
+++ b/gschem/src/g_window.c
@@ -82,8 +82,9 @@ g_scm_from_window (GschemToplevel *w_current)
 {
   g_assert (w_current != NULL);
 
-  if (w_current->smob == SCM_UNDEFINED) {
+  if (scm_is_eq (w_current->smob, SCM_UNDEFINED)) {
     SCM_NEWSMOB (w_current->smob, window_smob_tag, w_current);
+    scm_gc_protect_object (w_current->smob);
   }
 
   return w_current->smob;

--- a/gschem/src/gschemhotkeystore.c
+++ b/gschem/src/gschemhotkeystore.c
@@ -130,7 +130,7 @@ gschem_hotkey_store_rebuild (GschemHotkeyStore *store)
   g_assert (GSCHEM_IS_HOTKEY_STORE (store));
 
   /* First run the Scheme function to dump the global keymap */
-  if (s_expr == SCM_UNDEFINED) {
+  if (scm_is_eq (s_expr, SCM_UNDEFINED)) {
     s_expr = scm_permanent_object (scm_list_1 (scm_from_utf8_symbol (HELPER_FUNC_NAME)));
   }
   s_lst = g_scm_eval_protected (s_expr, SCM_UNDEFINED);
@@ -195,7 +195,7 @@ gschem_hotkey_store_action_property_handler (GschemHotkeyStore *store,
    * args should be a list of the form (action key value).  We only
    * want to rebuild the store if the change is to a label or to an
    * icon. */
-  if (label_sym == SCM_UNDEFINED) {
+  if (scm_is_eq (label_sym, SCM_UNDEFINED)) {
     label_sym = scm_permanent_object (scm_from_utf8_symbol ("label"));
     icon_sym = scm_permanent_object (scm_from_utf8_symbol ("icon"));
   }
@@ -221,7 +221,7 @@ gschem_hotkey_store_bind_keys_handler (GschemHotkeyStore *store,
 
   g_assert (GSCHEM_IS_HOTKEY_STORE (store));
 
-  if (global_keymap_sym == SCM_UNDEFINED) {
+  if (scm_is_eq (global_keymap_sym, SCM_UNDEFINED)) {
     global_keymap_sym =
       scm_permanent_object (scm_from_utf8_symbol ("%global-keymap"));
   }

--- a/gschem/src/x_window.c
+++ b/gschem/src/x_window.c
@@ -815,9 +815,10 @@ void x_window_close(GschemToplevel *w_current)
     o_buffer_free (w_current);
   }
 
-  /* Clear Guile smob weak ref */
-  if (w_current->smob != SCM_UNDEFINED) {
+  /* Allow Scheme value for this window to be garbage-collected */
+  if (!scm_is_eq (w_current->smob, SCM_UNDEFINED)) {
     SCM_SET_SMOB_DATA (w_current->smob, NULL);
+    scm_gc_unprotect_object (w_current->smob);
     w_current->smob = SCM_UNDEFINED;
   }
 

--- a/libgeda/include/libgedaguile_priv.h
+++ b/libgeda/include/libgedaguile_priv.h
@@ -99,6 +99,11 @@ void edascm_init_deprecated ();
 
 /* ---------------------------------------- */
 
+/*! Test whether a Scheme value has a defined value */
+#define edascm_is_defined(x) (!scm_is_eq((x), SCM_UNDEFINED))
+
+/* ---------------------------------------- */
+
 /* Macros and constants for working with the geda smob type. These are
  * for the convenience of the other C functions used by the Scheme
  * API. */

--- a/libgeda/src/edascmhookproxy.c
+++ b/libgeda/src/edascmhookproxy.c
@@ -122,7 +122,7 @@ edascm_hook_proxy_finalize (GObject *object)
   EdascmHookProxy *proxy = EDASCM_HOOK_PROXY (object);
 
   edascm_hook_proxy_disconnect (proxy);
-  if (proxy->priv->closure != SCM_UNDEFINED) {
+  if (edascm_is_defined (proxy->priv->closure)) {
     scm_gc_unprotect_object (proxy->priv->closure);
   }
 
@@ -142,7 +142,7 @@ edascm_hook_proxy_set_property (GObject *object, guint property_id,
 
   case PROP_HOOK:
     hook = edascm_value_get_scm (value);
-    if (hook == SCM_UNDEFINED) {
+    if (!edascm_is_defined (hook)) {
       edascm_hook_proxy_disconnect (proxy);
     } else {
       edascm_hook_proxy_connect (proxy, hook);
@@ -182,7 +182,7 @@ edascm_hook_proxy_connect (EdascmHookProxy *proxy, SCM hook)
   g_return_if_fail (SCM_HOOKP (hook));
   g_return_if_fail (scm_is_true (scm_procedure_p (proxy->priv->closure)));
 
-  if (proxy->priv->hook != SCM_UNDEFINED)
+  if (edascm_is_defined (proxy->priv->hook))
     edascm_hook_proxy_disconnect (proxy);
 
   proxy->priv->hook = hook;
@@ -198,7 +198,7 @@ edascm_hook_proxy_disconnect (EdascmHookProxy *proxy)
   g_return_if_fail (EDASCM_IS_HOOK_PROXY (proxy));
   g_return_if_fail (scm_is_true (scm_procedure_p (proxy->priv->closure)));
 
-  if (proxy->priv->hook == SCM_UNDEFINED) return;
+  if (!edascm_is_defined (proxy->priv->hook)) return;
 
   /* \bug What if scm_remove_hook_x() fails? */
   scm_remove_hook_x (proxy->priv->hook, proxy->priv->closure);

--- a/libgeda/src/edascmvaluetypes.c
+++ b/libgeda/src/edascmvaluetypes.c
@@ -54,7 +54,7 @@ value_init_scm (GValue *value) {
 static void
 value_free_scm (GValue *value) {
   SCM val = SCM_PACK (value->data[0].v_long);
-  if (val != SCM_UNDEFINED)
+  if (edascm_is_defined (val))
     scm_gc_unprotect_object (val);
 }
 
@@ -72,7 +72,7 @@ value_free_scm (GValue *value) {
 static void
 value_copy_scm (const GValue *src, GValue *dest) {
   SCM val = SCM_PACK (src->data[0].v_long);
-  if (val != SCM_UNDEFINED) {
+  if (edascm_is_defined (val)) {
     scm_gc_protect_object (val);
   }
   dest->data[0].v_long = SCM_UNPACK (val);
@@ -113,7 +113,7 @@ value_collect_scm (GValue *value,
 {
   SCM val = SCM_PACK (collect_values[0].v_long);
 
-  if (val != SCM_UNDEFINED) {
+  if (edascm_is_defined (val)) {
     /* never honour G_VALUE_NOCOPY_CONTENTS for ref-counted types */
     scm_gc_protect_object (val);
     value->data[0].v_long = SCM_UNPACK (val);
@@ -149,7 +149,7 @@ value_lcopy_scm (const GValue *value,
     return g_strdup_printf ("value location for `%s' passed as NULL",
                             G_VALUE_TYPE_NAME (value));
 
-  if (val == SCM_UNDEFINED) {
+  if (!edascm_is_defined (val)) {
     /* No value */
     *long_p = SCM_UNPACK (SCM_UNDEFINED);
   } else if (collect_flags & G_VALUE_NOCOPY_CONTENTS) {
@@ -230,14 +230,14 @@ edascm_value_set_scm (GValue *value, SCM v_scm)
 
   old = SCM_PACK (value->data[0].v_long);
 
-  if (v_scm != SCM_UNDEFINED) {
+  if (edascm_is_defined (v_scm)) {
     value->data[0].v_long = SCM_UNPACK (v_scm);
     scm_gc_protect_object (v_scm);
   } else {
     value->data[0].v_long = SCM_UNPACK (SCM_UNDEFINED);
   }
 
-  if (old != SCM_UNDEFINED)
+  if (edascm_is_defined (old))
     scm_gc_unprotect_object (old);
 }
 

--- a/libgeda/src/g_basic.c
+++ b/libgeda/src/g_basic.c
@@ -95,7 +95,7 @@ SCM g_scm_eval_protected (SCM exp, SCM module_or_state)
   SCM body_data;
   SCM result;
 
-  if (module_or_state == SCM_UNDEFINED) {
+  if (scm_is_eq (module_or_state, SCM_UNDEFINED)) {
     body_data = scm_list_2 (exp, scm_interaction_environment ());
   } else {
     body_data = scm_list_2 (exp, module_or_state);

--- a/libgeda/src/g_rc.c
+++ b/libgeda/src/g_rc.c
@@ -187,7 +187,7 @@ g_rc_parse_file (TOPLEVEL *toplevel, const gchar *rcfile,
 
   /* If the fluid for storing the relevant configuration context for
    * RC file reading hasn't been created yet, create it. */
-  if (scheme_rc_config_fluid == SCM_UNDEFINED)
+  if (scm_is_eq (scheme_rc_config_fluid, SCM_UNDEFINED))
     scheme_rc_config_fluid = scm_permanent_object (scm_make_fluid ());
 
   /* Normalise filename */
@@ -462,7 +462,7 @@ SCM g_rc_component_library(SCM path, SCM name)
               SCM_ARG1, "component-library");
 
   scm_dynwind_begin (0);
-  if (name != SCM_UNDEFINED) {
+  if (!scm_is_eq (name, SCM_UNDEFINED)) {
     SCM_ASSERT (scm_is_string (name), name,
 		SCM_ARG2, "component-library");
     namestr = scm_to_utf8_string (name);
@@ -837,7 +837,8 @@ SCM g_rc_always_promote_attributes(SCM attrlist)
     }
     g_strfreev(attr2);
   } else {
-    SCM_ASSERT(scm_list_p(attrlist), attrlist, SCM_ARG1, "always-promote-attributes");
+    SCM_ASSERT(scm_is_true (scm_list_p (attrlist)), attrlist, SCM_ARG1,
+               "always-promote-attributes");
     length = scm_ilength(attrlist);
     /* convert the scm list into a GList */
     for (i=0; i < length; i++) {
@@ -880,7 +881,7 @@ SCM g_rc_make_backup_files(SCM mode)
 
 SCM g_rc_print_color_map (SCM scm_map)
 {
-  if (scm_map == SCM_UNDEFINED) {
+  if (scm_is_eq (scm_map, SCM_UNDEFINED)) {
     return s_color_map_to_scm (print_colors);
   }
 

--- a/libgeda/src/geda_color.c
+++ b/libgeda/src/geda_color.c
@@ -202,7 +202,7 @@ s_color_map_from_scm (GedaColor *map, SCM lst, const char *scheme_proc_name)
   SCM curr = lst;
   SCM wrong_type_arg_sym = scm_from_utf8_symbol ("wrong-type-arg");
   SCM proc_name = scm_from_utf8_string (scheme_proc_name);
-  while (curr != SCM_EOL) {
+  while (!scm_is_null (curr)) {
     int i;
     char *rgba;
     SCM s;

--- a/libgeda/src/s_clib.c
+++ b/libgeda/src/s_clib.c
@@ -725,13 +725,13 @@ static void refresh_scm (CLibSource *source)
 
   symlist = scm_call_0 (source->list_fn);
 
-  if (SCM_NCONSP (symlist) && (symlist != SCM_EOL)) {
+  if (scm_is_false (scm_list_p (symlist))) {
     s_log_message (_("Failed to scan library [%s]: Scheme function returned non-list\n"),
 		   source->name);
     return;
   }
 
-  while (symlist != SCM_EOL) {
+  while (!scm_is_null (symlist)) {
     symname = SCM_CAR (symlist);
     if (!scm_is_string (symname)) {
       s_log_message (_("Non-string symbol name while scanning library [%s]\n"),

--- a/libgeda/src/scheme_config.c
+++ b/libgeda/src/scheme_config.c
@@ -1019,7 +1019,7 @@ static void
 edascm_config_event_dispatcher (EdaConfig *cfg, const char *group,
                                 const char *key, void *user_data)
 {
-  SCM proc_s = (SCM) user_data;
+  SCM proc_s = SCM_PACK ((scm_t_bits) user_data);
   SCM expr = scm_list_4 (proc_s,
                          edascm_from_config (cfg),
                          scm_from_utf8_string (group),
@@ -1069,7 +1069,7 @@ SCM_DEFINE (add_config_event_x, "%add-config-event!", 2, 0, 0,
                            0,
                            NULL,
                            edascm_config_event_dispatcher,
-                           (gpointer) proc_s);
+                           (gpointer) SCM_UNPACK (proc_s));
   if (handler_id) {
     return cfg_s;
   }
@@ -1077,7 +1077,7 @@ SCM_DEFINE (add_config_event_x, "%add-config-event!", 2, 0, 0,
   /* Protect proc_s against garbage collection */
   g_signal_connect (cfg, "config-changed",
                     G_CALLBACK (edascm_config_event_dispatcher),
-                    (gpointer) scm_gc_protect_object (proc_s));
+                    (gpointer) SCM_UNPACK (scm_gc_protect_object (proc_s)));
   return cfg_s;
 }
 
@@ -1112,7 +1112,7 @@ SCM_DEFINE (remove_config_event_x, "%remove-config-event!", 2, 0, 0,
                                           0,
                                           NULL,
                                           edascm_config_event_dispatcher,
-                                          (gpointer) proc_s);
+                                          (gpointer) SCM_UNPACK (proc_s));
   g_warn_if_fail (found < 2);
   if (found) {
     scm_gc_unprotect_object (proc_s);

--- a/libgeda/src/scheme_log.c
+++ b/libgeda/src/scheme_log.c
@@ -43,12 +43,12 @@ SCM_SYMBOL(debug_sym, "debug");
 static GLogLevelFlags
 decode_level (SCM level_s)
 {
-	if (level_s == error_sym)    return (G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL);
-	if (level_s == critical_sym) return G_LOG_LEVEL_CRITICAL;
-	if (level_s == warning_sym)  return G_LOG_LEVEL_WARNING;
-	if (level_s == message_sym)  return G_LOG_LEVEL_MESSAGE;
-	if (level_s == info_sym)     return G_LOG_LEVEL_INFO;
-	if (level_s == debug_sym)    return G_LOG_LEVEL_DEBUG;
+	if (scm_is_eq (level_s, error_sym))    return (G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL);
+	if (scm_is_eq (level_s, critical_sym)) return G_LOG_LEVEL_CRITICAL;
+	if (scm_is_eq (level_s, warning_sym))  return G_LOG_LEVEL_WARNING;
+	if (scm_is_eq (level_s, message_sym))  return G_LOG_LEVEL_MESSAGE;
+	if (scm_is_eq (level_s, info_sym))     return G_LOG_LEVEL_INFO;
+	if (scm_is_eq (level_s, debug_sym))    return G_LOG_LEVEL_DEBUG;
 
 	g_return_val_if_reached(G_LOG_LEVEL_MESSAGE);
 }

--- a/libgeda/src/scheme_object.c
+++ b/libgeda/src/scheme_object.c
@@ -105,7 +105,7 @@ edascm_to_object_glist (SCM objs, const char *subr)
   scm_dynwind_begin (0);
   scm_dynwind_unwind_handler ((void (*)(void *))g_list_free, result, 0);
 
-  for (lst = objs; lst != SCM_EOL; lst = SCM_CDR (lst)) {
+  for (lst = objs; !scm_is_null (lst); lst = SCM_CDR (lst)) {
     SCM smob = SCM_CAR (lst);
     result = g_list_prepend (result, (gpointer) edascm_to_object (smob));
   }
@@ -445,20 +445,20 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
 
   width = scm_to_int (width_s);
 
-  if      (cap_s == none_sym)   { cap = END_NONE;   }
-  else if (cap_s == square_sym) { cap = END_SQUARE; }
-  else if (cap_s == round_sym)  { cap = END_ROUND;  }
+  if      (scm_is_eq (cap_s, none_sym))   { cap = END_NONE;   }
+  else if (scm_is_eq (cap_s, square_sym)) { cap = END_SQUARE; }
+  else if (scm_is_eq (cap_s, round_sym))  { cap = END_ROUND;  }
   else {
     scm_misc_error (s_set_object_stroke_x,
                     _("Invalid stroke cap style ~A."),
                     scm_list_1 (cap_s));
   }
 
-  if      (dash_s == solid_sym)   { type = TYPE_SOLID;   }
-  else if (dash_s == dotted_sym)  { type = TYPE_DOTTED;  }
-  else if (dash_s == dashed_sym)  { type = TYPE_DASHED;  }
-  else if (dash_s == center_sym)  { type = TYPE_CENTER;  }
-  else if (dash_s == phantom_sym) { type = TYPE_PHANTOM; }
+  if      (scm_is_eq (dash_s, solid_sym))   { type = TYPE_SOLID;   }
+  else if (scm_is_eq (dash_s, dotted_sym))  { type = TYPE_DOTTED;  }
+  else if (scm_is_eq (dash_s, dashed_sym))  { type = TYPE_DASHED;  }
+  else if (scm_is_eq (dash_s, center_sym))  { type = TYPE_CENTER;  }
+  else if (scm_is_eq (dash_s, phantom_sym)) { type = TYPE_PHANTOM; }
   else {
     scm_misc_error (s_set_object_stroke_x,
                     _("Invalid stroke dash style ~A."),
@@ -469,7 +469,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
   case TYPE_DASHED:
   case TYPE_CENTER:
   case TYPE_PHANTOM:
-    if (length_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (length_s)) {
       scm_misc_error (s_set_object_stroke_x,
                       _("Missing dash length parameter for dash style ~A."),
                       scm_list_1 (length_s));
@@ -479,7 +479,7 @@ SCM_DEFINE (set_object_stroke_x, "%set-object-stroke!", 4, 2, 0,
     length = scm_to_int (length_s);
     /* This case intentionally falls through */
   case TYPE_DOTTED:
-    if (space_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (space_s)) {
       scm_misc_error (s_set_object_stroke_x,
                       _("Missing dot/dash space parameter for dash style ~A."),
                       scm_list_1 (space_s));
@@ -586,10 +586,10 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
   OBJECT *obj = edascm_to_object (obj_s);
   int type, width = -1, angle1 = -1, space1 = -1, angle2 = -1, space2 = -1;
 
-  if      (type_s == hollow_sym)   { type = FILLING_HOLLOW;   }
-  else if (type_s == solid_sym) { type = FILLING_FILL; }
-  else if (type_s == hatch_sym)  { type = FILLING_HATCH;  }
-  else if (type_s == mesh_sym)  { type = FILLING_MESH;  }
+  if      (scm_is_eq (type_s, hollow_sym)) { type = FILLING_HOLLOW;   }
+  else if (scm_is_eq (type_s, solid_sym))  { type = FILLING_FILL; }
+  else if (scm_is_eq (type_s, hatch_sym))  { type = FILLING_HATCH;  }
+  else if (scm_is_eq (type_s, mesh_sym))   { type = FILLING_MESH;  }
   else {
     scm_misc_error (s_set_object_fill_x,
                     _("Invalid fill style ~A."),
@@ -598,7 +598,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
 
   switch (type) {
   case FILLING_MESH:
-    if (space2_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (space2_s)) {
       scm_misc_error (s_set_object_fill_x,
                       _("Missing second space parameter for fill style ~A."),
                       scm_list_1 (space2_s));
@@ -607,7 +607,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
                 SCM_ARG6, s_set_object_fill_x);
     space2 = scm_to_int (space2_s);
 
-    if (angle2_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (angle2_s)) {
       scm_misc_error (s_set_object_fill_x,
                       _("Missing second angle parameter for fill style ~A."),
                       scm_list_1 (angle2_s));
@@ -617,7 +617,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
     angle2 = scm_to_int (angle2_s);
     /* This case intentionally falls through */
   case FILLING_HATCH:
-    if (width_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (width_s)) {
       scm_misc_error (s_set_object_fill_x,
                       _("Missing stroke width parameter for fill style ~A."),
                       scm_list_1 (width_s));
@@ -626,7 +626,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
                 SCM_ARG3, s_set_object_fill_x);
     width = scm_to_int (width_s);
 
-    if (space1_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined (space1_s)) {
       scm_misc_error (s_set_object_fill_x,
                       _("Missing space parameter for fill style ~A."),
                       scm_list_1 (space1_s));
@@ -635,7 +635,7 @@ SCM_DEFINE (set_object_fill_x, "%set-object-fill!", 2, 5, 0,
                 SCM_ARG4, s_set_object_fill_x);
     space1 = scm_to_int (space1_s);
 
-    if (angle1_s == SCM_UNDEFINED) {
+    if (!edascm_is_defined(angle1_s)) {
       scm_misc_error (s_set_object_fill_x,
                       _("Missing angle parameter for fill style ~A."),
                       scm_list_1 (angle1_s));
@@ -939,9 +939,9 @@ SCM_DEFINE (make_pin, "%make-pin", 1, 0, 0,
               type_s, SCM_ARG1, s_make_pin);
 
   int type;
-  if (type_s == net_sym) {
+  if (scm_is_eq (type_s, net_sym)) {
     type = PIN_TYPE_NET;
-  } else if (type_s == bus_sym) {
+  } else if (scm_is_eq (type_s, bus_sym)) {
     type = PIN_TYPE_BUS;
   } else {
     scm_misc_error (s_make_pin,
@@ -1389,15 +1389,15 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
 
   /* Alignment. Sadly we can't switch on pointers. :-( */
   int align;
-  if      (align_s == lower_left_sym)    { align = LOWER_LEFT;    }
-  else if (align_s == middle_left_sym)   { align = MIDDLE_LEFT;   }
-  else if (align_s == upper_left_sym)    { align = UPPER_LEFT;    }
-  else if (align_s == lower_center_sym)  { align = LOWER_MIDDLE;  }
-  else if (align_s == middle_center_sym) { align = MIDDLE_MIDDLE; }
-  else if (align_s == upper_center_sym)  { align = UPPER_MIDDLE;  }
-  else if (align_s == lower_right_sym)   { align = LOWER_RIGHT;   }
-  else if (align_s == middle_right_sym)  { align = MIDDLE_RIGHT;  }
-  else if (align_s == upper_right_sym)   { align = UPPER_RIGHT;   }
+  if      (scm_is_eq (align_s, lower_left_sym))    { align = LOWER_LEFT;    }
+  else if (scm_is_eq (align_s, middle_left_sym))   { align = MIDDLE_LEFT;   }
+  else if (scm_is_eq (align_s, upper_left_sym))    { align = UPPER_LEFT;    }
+  else if (scm_is_eq (align_s, lower_center_sym))  { align = LOWER_MIDDLE;  }
+  else if (scm_is_eq (align_s, middle_center_sym)) { align = MIDDLE_MIDDLE; }
+  else if (scm_is_eq (align_s, upper_center_sym))  { align = UPPER_MIDDLE;  }
+  else if (scm_is_eq (align_s, lower_right_sym))   { align = LOWER_RIGHT;   }
+  else if (scm_is_eq (align_s, middle_right_sym))  { align = MIDDLE_RIGHT;  }
+  else if (scm_is_eq (align_s, upper_right_sym))   { align = UPPER_RIGHT;   }
   else {
     scm_misc_error (s_set_text_x,
                     _("Invalid text alignment ~A."),
@@ -1430,9 +1430,9 @@ SCM_DEFINE (set_text_x, "%set-text!", 10, 0, 0,
 
   /* Name/value visibility */
   int show;
-  if      (show_s == name_sym)  { show = SHOW_NAME;       }
-  else if (show_s == value_sym) { show = SHOW_VALUE;      }
-  else if (show_s == both_sym)  { show = SHOW_NAME_VALUE; }
+  if      (scm_is_eq (show_s, name_sym))  { show = SHOW_NAME;       }
+  else if (scm_is_eq (show_s, value_sym)) { show = SHOW_VALUE;      }
+  else if (scm_is_eq (show_s, both_sym))  { show = SHOW_NAME_VALUE; }
   else {
     scm_misc_error (s_set_text_x,
                     _("Invalid text name/value visibility ~A."),
@@ -1830,10 +1830,10 @@ SCM_DEFINE (path_insert_x, "%path-insert", 3, 6, 0,
   PATH_SECTION section = {0, 0, 0, 0, 0, 0, 0};
 
   /* Check & extract path element type. */
-  if      (type_s == closepath_sym) { section.code = PATH_END;     }
-  else if (type_s == moveto_sym)    { section.code = PATH_MOVETO;  }
-  else if (type_s == lineto_sym)    { section.code = PATH_LINETO;  }
-  else if (type_s == curveto_sym)   { section.code = PATH_CURVETO; }
+  if      (scm_is_eq (type_s, closepath_sym)) { section.code = PATH_END;     }
+  else if (scm_is_eq (type_s, moveto_sym))    { section.code = PATH_MOVETO;  }
+  else if (scm_is_eq (type_s, lineto_sym))    { section.code = PATH_LINETO;  }
+  else if (scm_is_eq (type_s, curveto_sym))   { section.code = PATH_CURVETO; }
   else {
     scm_misc_error (s_path_insert_x,
                     _("Invalid path element type ~A."),

--- a/utils/gschlas/g_rc.c
+++ b/utils/gschlas/g_rc.c
@@ -62,7 +62,7 @@ SCM g_rc_gschlas_version(SCM scm_version)
     if (g_ascii_strcasecmp (version, PACKAGE_DATE_VERSION) != 0) {
       sourcefile = NULL;
       rc_filename = g_rc_rc_filename ();
-      if (rc_filename == SCM_BOOL_F) {
+      if (scm_is_false (rc_filename)) {
         rc_filename = scm_from_utf8_string ("unknown");
       }
       sourcefile = scm_to_utf8_string (rc_filename);


### PR DESCRIPTION
Many libguile functions used by geda-gaf are actually macros.  These macros do some magic that's intended to generate compile-time errors if they are misused, while still generating efficient code.  Unfortunately, with the default build settings, these macros actually generate code that has undefined behaviour according to the C standard. This undefined behaviour makes static analysis tools like Coverity Scan quite upset.

By defining `SCM_DEBUG_TYPING_STRICTNESS=2` while building geda-gaf, much of the magic can be avoided.  However, setting this increased strictness level exposes a number of places where geda-gaf (and especially libgeda) is not handling `SCM` values correctly.  These patches ensure that geda-gaf can be built with `SCM_DEBUG_TYPING_STRICTNESS=2` without any additional errors or warnings.