### PR TITLE
Fix defects detected by Coverity Scan

### DIFF
--- a/gschem/src/gschem_close_confirmation_dialog.c
+++ b/gschem/src/gschem_close_confirmation_dialog.c
@@ -180,7 +180,9 @@ count_pages (GtkTreeModel *model)
   GtkTreeIter iter;
   gint n_pages;
 
-  gtk_tree_model_get_iter_first (model, &iter);
+  if (!gtk_tree_model_get_iter_first (model, &iter)) {
+    return 0;
+  }
   for (n_pages = 1;
        gtk_tree_model_iter_next (model, &iter);
        n_pages++);

--- a/libgeda/src/g_basic.c
+++ b/libgeda/src/g_basic.c
@@ -239,7 +239,8 @@ static void
 process_error_stack (SCM s_stack, SCM s_key, SCM s_args, GError **err) {
   char *long_message;
   char *short_message;
-  SCM s_port, s_subr, s_message, s_message_args, s_rest, s_location;
+  SCM s_port, s_subr, s_message, s_message_args, s_rest;
+  SCM s_location = SCM_BOOL_F;
 
   /* Split s_args up */
   s_rest = s_args;
@@ -261,7 +262,6 @@ process_error_stack (SCM s_stack, SCM s_key, SCM s_args, GError **err) {
     scm_puts ("\n", s_port);
   }
 
-  s_location = SCM_BOOL_F;
 #ifdef HAVE_SCM_DISPLAY_ERROR_STACK
   s_location = s_stack;
 #endif /* HAVE_SCM_DISPLAY_ERROR_STACK */

--- a/libgeda/src/scheme_log.c
+++ b/libgeda/src/scheme_log.c
@@ -87,8 +87,8 @@ SCM_DEFINE (log_x, "%log!", 3, 0, 0,
 
 	scm_dynwind_begin(0);
 	gchar *domain = NULL;
-	if (domain) {
-		scm_to_utf8_string(domain_s);
+	if (scm_is_string (domain_s)) {
+		domain = scm_to_utf8_string(domain_s);
 		scm_dynwind_free(domain);
 	}
 	gchar *message = scm_to_utf8_string(message_s);

--- a/libgedacairo/edarenderer.c
+++ b/libgedacairo/edarenderer.c
@@ -1168,6 +1168,7 @@ eda_renderer_draw_grips_impl (EdaRenderer *renderer, int type, int n_grips, ...)
                             0, 360);
       break;
     default:
+      va_end (coordinates);
       g_return_if_reached ();
     }
 


### PR DESCRIPTION
These patches fix all outstanding defects that the Coverity Scan static analysis system detected in libgeda, libgedacairo, gaf, gschem and gnetlist.

Most of the remaining defects -- many of them serious -- are located in very old and unmaintained contributed tools.