### PR TITLE
libgeda: Set world size values directly s_toplevel_new()

### DIFF
--- a/libgeda/src/geda_toplevel.c
+++ b/libgeda/src/geda_toplevel.c
@@ -2,7 +2,7 @@
  * libgeda - gEDA's library
  * Copyright (C) 1998, 1999, 2000 Kazu Hirata / Ales Hvezda
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2013 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,10 +51,15 @@ TOPLEVEL *s_toplevel_new (void)
 
   toplevel->bitmap_directory   = NULL;
 
-  toplevel->init_left = 0;
-  toplevel->init_top  = 0;
-  toplevel->init_right  = 0;
-  toplevel->init_bottom = 0;
+  /* These values are the default extents of the schematic drawing area.
+   *
+   * The negative values allow symbols, residing at the origin, to be
+   * edited without translation to other coordinates.
+   */
+  toplevel->init_left = -60500;
+  toplevel->init_top  = -45375;
+  toplevel->init_right  = 121000;
+  toplevel->init_bottom = 90750;
 
   toplevel->pages = geda_list_new();
   toplevel->page_current = NULL;

--- a/libgeda/src/i_vars.c
+++ b/libgeda/src/i_vars.c
@@ -1,7 +1,7 @@
 /* gEDA - GPL Electronic Design Automation
  * libgeda - gEDA's library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,16 +36,6 @@
 #define DEFAULT_BITMAP_DIRECTORY "../lib/bitmaps"
 #define DEFAULT_BUS_RIPPER_SYMNAME "busripper-1.sym"
 
-/* These values are the default extents of the schematic drawing area.
- *
- * The negative values allow symbols, residing at the origin, to be edited
- * without translation to other coordinates.
- */
-int   default_init_left = -60500;
-int   default_init_right = 121000;
-int   default_init_top = -45375;
-int   default_init_bottom = 90750;
-
 char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
 GList *default_always_promote_attributes = NULL;
@@ -66,11 +56,6 @@ int   default_make_backup_files = TRUE;
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
   GList *iter;
-
-  toplevel->init_left    = default_init_left;
-  toplevel->init_right   = default_init_right;
-  toplevel->init_top     = default_init_top;
-  toplevel->init_bottom  = default_init_bottom;
 
   toplevel->attribute_promotion = default_attribute_promotion;
   toplevel->promote_invisible = default_promote_invisible;


### PR DESCRIPTION
Since the `world-size` rc file procedure was removed in commit
8778fa18, there's no need for the indirection of world size values
via `i_vars_libgeda_set()`.