### PR TITLE
Intern attribute names and cache in text objects

### DIFF
--- a/gattrib/src/s_object.c
+++ b/gattrib/src/s_object.c
@@ -187,14 +187,13 @@ void s_object_replace_attrib_in_object(TOPLEVEL *toplevel,
 	&& a_current->text != NULL) {  /* found an attribute */
 
       /* may need to check more thoroughly here. . . . */
-      old_attrib_text = g_strdup(a_current->text->string);
+      old_attrib_text = g_strdup(geda_text_object_get_string (a_current));
       old_attrib_name = u_basic_breakup_string(old_attrib_text, '=', 0);
 
       if (strcmp(old_attrib_name, new_attrib_name) == 0) {
 	/* create attrib=value text string & stuff it back into toplevel */
 	new_attrib_text = g_strconcat(new_attrib_name, "=", new_attrib_value, NULL);
-	g_free(a_current->text->string);   /* remove old attrib string */
-	a_current->text->string = g_strdup(new_attrib_text);   /* insert new attrib string */
+  o_text_set_string (toplevel, a_current, new_attrib_text);
 	if (visibility != LEAVE_VISIBILITY_ALONE)
 	  o_set_visibility (toplevel, a_current, visibility);
 	if (show_name_value != LEAVE_NAME_VALUE_ALONE)
@@ -248,7 +247,7 @@ s_object_remove_attrib_in_object (TOPLEVEL *toplevel,
 	&& a_current->text != NULL) {  /* found an attribute */
 
       /* may need to check more thoroughly here. . . . */
-      old_attrib_text = g_strdup(a_current->text->string);
+      old_attrib_text = g_strdup(geda_text_object_get_string (a_current));
       old_attrib_name = u_basic_breakup_string(old_attrib_text, '=', 0);
 
       if (strcmp(old_attrib_name, new_attrib_name) == 0) {

--- a/gattrib/src/s_sheet_data.c
+++ b/gattrib/src/s_sheet_data.c
@@ -204,7 +204,7 @@ void s_sheet_data_add_master_comp_attrib_list_items (const GList *obj_list) {
 	  a_current = a_iter->data;
 	  if (a_current->type == OBJ_TEXT
 	      && a_current->text != NULL) {  /* found an attribute */
-	    attrib_text = g_strdup(a_current->text->string);
+	    attrib_text = g_strdup(geda_text_object_get_string (a_current));
 	    attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
 
 	      /* Don't include "refdes" or "slot" because they form the row name */
@@ -416,7 +416,7 @@ void s_sheet_data_add_master_pin_attrib_list_items (const GList *obj_list) {
 		pin_attrib = a_iter->data;
 		if (pin_attrib->type == OBJ_TEXT
 		    && pin_attrib->text != NULL) {  /* found an attribute */
-		  attrib_text = g_strdup(pin_attrib->text->string);
+		  attrib_text = g_strdup(geda_text_object_get_string (pin_attrib));
 		  attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
 		  attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
 		  if ( (strcmp(attrib_name, "pinnumber") != 0) 

--- a/gattrib/src/s_table.c
+++ b/gattrib/src/s_table.c
@@ -321,7 +321,7 @@ void s_table_add_toplevel_comp_items_to_comp_table (const GList *obj_list) {
           if (a_current->type == OBJ_TEXT
               && a_current->text != NULL) {  /* found an attribute */
             /* may need to check more thoroughly here. . . . */
-            attrib_text = g_strdup(a_current->text->string);
+            attrib_text = g_strdup(geda_text_object_get_string (a_current));
             attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
             attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
             old_visibility = o_is_visible (pr_current, a_current)
@@ -533,7 +533,7 @@ void s_table_add_toplevel_pin_items_to_pin_table (const GList *obj_list) {
 	      pin_attrib = a_iter->data;
 	      if (pin_attrib->type == OBJ_TEXT
 		  && pin_attrib->text != NULL) {  /* found an attribute */
-		attrib_text = g_strdup(pin_attrib->text->string);
+          attrib_text = g_strdup(geda_text_object_get_string (pin_attrib));
 		attrib_name = u_basic_breakup_string(attrib_text, '=', 0);
 		attrib_value = s_misc_remaining_string(attrib_text, '=', 1);
  

--- a/gattrib/src/s_toplevel.c
+++ b/gattrib/src/s_toplevel.c
@@ -659,7 +659,7 @@ s_toplevel_update_component_attribs_in_toplevel (
     if (a_current->type == OBJ_TEXT
 	&& a_current->text != NULL) {  /* found a name=value attribute pair. */
       /* may need to check more thoroughly here. . . . */
-      old_name_value_pair = g_strdup(a_current->text->string);
+      old_name_value_pair = g_strdup(geda_text_object_get_string (a_current));
 
       /* Else clause is suggestion from Ales */
 #if 1

--- a/gschem/src/o_misc.c
+++ b/gschem/src/o_misc.c
@@ -76,7 +76,7 @@ void o_edit(GschemToplevel *w_current, GList *list)
     break;
     case(OBJ_TEXT):
       str = geda_text_object_get_string (o_current);
-      if (o_attrib_get_name_value (o_current, NULL, NULL) &&
+      if (o_attrib_is_attrib (o_current) &&
         /* attribute editor only accept 1-line values for attribute */
         o_text_num_lines (str) == 1) {
         attrib_edit_dialog(w_current,o_current, FROM_MENU);

--- a/gschem/src/x_compselect.c
+++ b/gschem/src/x_compselect.c
@@ -421,7 +421,8 @@ tree_row_activated (GtkTreeView       *tree_view,
 static gint
 sort_object_text (OBJECT *a, OBJECT *b)
 {
-  return strcmp (a->text->string, b->text->string);
+  return strcmp (geda_text_object_get_string (a),
+                 geda_text_object_get_string (b));
 }
 
 enum {

--- a/gschem/src/x_multiattrib.c
+++ b/gschem/src/x_multiattrib.c
@@ -2473,8 +2473,7 @@ lone_attributes_to_model_rows (Multiattrib *multiattrib)
     MODEL_ROW *m_row;
 
     /* Consider a selected text object might be an attribute */
-    if (object->type != OBJ_TEXT ||
-        !o_attrib_get_name_value (object, NULL, NULL))
+    if (object->type != OBJ_TEXT || !o_attrib_is_attrib (object))
       continue;
 
     /* We have an OBJ_TEXT which libgeda can parse as an attribute */

--- a/gsymcheck/src/s_check.c
+++ b/gsymcheck/src/s_check.c
@@ -207,7 +207,7 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
     OBJECT *o_current = iter->data;
 
     if (o_current->type == OBJ_TEXT) {
-      tokens = g_strsplit(o_current->text->string,"=", 2);
+      tokens = g_strsplit(geda_text_object_get_string (o_current),"=", 2);
       if (tokens[0] != NULL && tokens[1] != NULL) {
 	if (s_check_list_has_item(forbidden_attributes, tokens[0])) {
 	  message = g_strdup_printf (_("Found forbidden %s= attribute: [%s=%s]\n"),
@@ -252,7 +252,7 @@ s_check_symbol_structure (const GList *obj_list, SYMCHECK *s_current)
         if (o_current->show_name_value != SHOW_NAME_VALUE) {
           message = g_strdup_printf (_("Found a simple text object with only SHOW_NAME"
                                      " or SHOW_VALUE set [%s]\n"),
-                                     o_current->text->string);
+                                     geda_text_object_get_string (o_current));
           s_current->warning_messages =
             g_list_append(s_current->warning_messages, message);
           s_current->warning_count++;
@@ -270,7 +270,8 @@ s_check_text (const GList *obj_list, SYMCHECK *s_current)
   OBJECT *o_current;
   gboolean overbar_started, escape, leave_parser;
   char *message;
-  char *text_string, *ptr;
+  const char *text_string;
+  const char *ptr;
   gunichar current_char;
 
   for (iter = obj_list; iter != NULL; iter = g_list_next(iter)) {
@@ -280,7 +281,7 @@ s_check_text (const GList *obj_list, SYMCHECK *s_current)
       continue;
 
     overbar_started = escape = leave_parser = FALSE;
-    text_string = o_current->text->string;
+    text_string = geda_text_object_get_string (o_current);
 
     for (ptr = text_string;
          ptr != NULL && !leave_parser;
@@ -1061,7 +1062,7 @@ void
 s_check_oldpin (const GList *obj_list, SYMCHECK *s_current)
 {
   const GList *iter;
-  char *ptr;
+  const char *ptr;
   int found_old = FALSE;
   int number_counter = 0;
   char *message;
@@ -1071,10 +1072,10 @@ s_check_oldpin (const GList *obj_list, SYMCHECK *s_current)
 
     if (o_current->type == OBJ_TEXT)
     {
-      if (strstr(o_current->text->string, "pin"))
+      if (strstr(geda_text_object_get_string (o_current), "pin"))
       {
         /* skip over "pin" */
-        ptr = o_current->text->string + 3;
+        ptr = geda_text_object_get_string (o_current) + 3;
 
         found_old = FALSE;
         number_counter = 0;
@@ -1114,7 +1115,7 @@ s_check_oldpin (const GList *obj_list, SYMCHECK *s_current)
         {
           message = g_strdup_printf (
             _("Found old pin#=# attribute: %s\n"),
-            o_current->text->string);
+            geda_text_object_get_string (o_current));
           s_current->error_messages = g_list_append(s_current->error_messages,
                                                     message);
 
@@ -1133,7 +1134,7 @@ void
 s_check_oldslot (const GList *obj_list, SYMCHECK *s_current)
 {
   const GList *iter;
-  char *ptr;
+  const char *ptr;
   int found_old = FALSE;
   int number_counter = 0;
   char *message;
@@ -1143,10 +1144,10 @@ s_check_oldslot (const GList *obj_list, SYMCHECK *s_current)
 
     if (o_current->type == OBJ_TEXT)
     {
-      if (strstr(o_current->text->string, "slot"))
+      if (strstr(geda_text_object_get_string (o_current), "slot"))
       {
         /* skip over "slot" */
-        ptr = o_current->text->string + 4;
+        ptr = geda_text_object_get_string (o_current) + 4;
 
         found_old = FALSE;
         number_counter = 0;
@@ -1186,7 +1187,7 @@ s_check_oldslot (const GList *obj_list, SYMCHECK *s_current)
         {
           message = g_strdup_printf (
             _("Found old slot#=# attribute: %s\n"),
-            o_current->text->string);
+            geda_text_object_get_string (o_current));
           s_current->error_messages = g_list_append(s_current->error_messages,
                                                     message);
           s_current->found_oldslot_attrib += found_old;
@@ -1322,19 +1323,19 @@ s_check_missing_attributes (const GList *obj_list, SYMCHECK *s_current)
 
     if (o_current->type == OBJ_TEXT)
     {
-      if (strstr(o_current->text->string, "footprint=")) {
+      if (strstr(geda_text_object_get_string (o_current), "footprint=")) {
         message = g_strdup_printf (
           _("Found %s attribute\n"),
-          o_current->text->string);
+          geda_text_object_get_string (o_current));
         s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
         s_current->found_footprint++;
       }
 
-      if (strstr(o_current->text->string, "refdes=")) {
+      if (strstr(geda_text_object_get_string (o_current), "refdes=")) {
         message = g_strdup_printf (
           _("Found %s attribute\n"),
-          o_current->text->string);
+          geda_text_object_get_string (o_current));
         s_current->info_messages = g_list_append(s_current->info_messages,
                                                message);
         s_current->found_refdes++;

--- a/libgeda/include/i_vars_priv.h
+++ b/libgeda/include/i_vars_priv.h
@@ -5,7 +5,7 @@ extern int default_init_bottom;
 extern char *default_bitmap_directory;
 extern char *default_bus_ripper_symname;
 
-extern GList *default_always_promote_attributes;
+extern GPtrArray *default_always_promote_attributes;
 
 extern int default_attribute_promotion;
 extern int default_promote_invisible;

--- a/libgeda/include/libgeda/geda_text.h
+++ b/libgeda/include/libgeda/geda_text.h
@@ -1,7 +1,7 @@
 /* gEDA - GPL Electronic Design Automation
  * libgeda - gEDA's library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2010,2017 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,4 +33,5 @@ struct st_text
   int size;
   int alignment;
   int angle;
+  const gchar *name; /* not owned by st_text */
 };

--- a/libgeda/include/libgeda/geda_toplevel.h
+++ b/libgeda/include/libgeda/geda_toplevel.h
@@ -75,7 +75,7 @@ struct st_toplevel
   int force_boundingbox;
 
   /* List of attributes to always promote */
-  GList *always_promote_attributes;
+  GPtrArray *always_promote_attributes;
 
   /* Callback function for calculating text bounds */
   RenderedBoundsFunc rendered_text_bounds_func;

--- a/libgeda/include/libgeda/prototype.h
+++ b/libgeda/include/libgeda/prototype.h
@@ -59,6 +59,7 @@ void o_attrib_print(GList *attributes);
 void o_attrib_remove(TOPLEVEL *toplevel, GList **list, OBJECT *remove);
 gboolean o_attrib_string_get_name_value (const gchar *string, gchar **name_ptr, gchar **value_ptr);
 gboolean o_attrib_get_name_value (OBJECT *attrib, gchar **name_ptr, gchar **value_ptr);
+const char *o_attrib_get_name (const OBJECT *attrib);
 GList *o_attrib_find_floating_attribs (const GList *list);
 char *o_attrib_search_floating_attribs_by_name (const GList *list, char *name, int counter);
 char *o_attrib_search_attached_attribs_by_name (OBJECT *object, char *name, int counter);

--- a/libgeda/include/libgeda/prototype.h
+++ b/libgeda/include/libgeda/prototype.h
@@ -67,6 +67,7 @@ char *o_attrib_search_inherited_attribs_by_name (OBJECT *object, char *name, int
 char *o_attrib_search_object_attribs_by_name (OBJECT *object, char *name, int counter);
 GList *o_attrib_return_attribs(OBJECT *object);
 int o_attrib_is_inherited(OBJECT *attrib);
+gboolean o_attrib_is_attrib (const OBJECT *attrib);
 
 /* o_embed.c */
 void o_embed(TOPLEVEL *toplevel, OBJECT *o_current);

--- a/libgeda/scheme/geda/attrib.scm
+++ b/libgeda/scheme/geda/attrib.scm
@@ -28,16 +28,13 @@
   #:use-module (geda page))
 
 (define-public parse-attrib %parse-attrib)
+(define-public attrib-name %attrib-name)
 (define-public object-attribs %object-attribs)
 (define-public attrib-attachment %attrib-attachment)
 (define-public promotable-attribs %promotable-attribs)
 
 (define-public (attribute? a)
-  (false-if-exception (and (parse-attrib a) #t)))
-
-(define-public (attrib-name a)
-  (let ((v (parse-attrib a)))
-    (if v (car v) v)))
+  (false-if-exception (and (attrib-name a) #t)))
 
 (define-public (attrib-value a)
   (let ((v (parse-attrib a)))

--- a/libgeda/src/geda_complex_object.c
+++ b/libgeda/src/geda_complex_object.c
@@ -1,7 +1,7 @@
 /* gEDA - GPL Electronic Design Automation
  * libgeda - gEDA's library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -151,24 +151,22 @@ geda_complex_object_get_position (const GedaObject *object, gint *x, gint *y)
  */
 static int o_complex_is_eligible_attribute (TOPLEVEL *toplevel, OBJECT *object)
 {
-  char *name = NULL;
-  int promotableAttribute = FALSE;
+  g_return_val_if_fail (toplevel, FALSE);
+  g_return_val_if_fail (object, FALSE);
+
+  const gchar *name = o_attrib_get_name (object);
+  if (!name) return FALSE;
 
   /* always promote symversion= attribute, even if it is invisible */
-  if (strncmp(object->text->string, "symversion=", 11) == 0)
+  if (strncmp(o_attrib_get_name(object), "symversion", 10) == 0)
     return TRUE;
 
   /* check list against attributes which can be promoted */
   if (toplevel->always_promote_attributes != NULL) {
-    if (o_attrib_get_name_value (object, &name, NULL)) {
-      if (g_list_find_custom(toplevel->always_promote_attributes,
-			     name, (GCompareFunc) strcmp) != NULL) {
-        /* Name of the attribute was in the always promote attributes list */
-        promotableAttribute = TRUE;
-      }
-
-      g_free(name);
-      if (promotableAttribute)
+    for (guint i = 0; i < toplevel->always_promote_attributes->len; ++i) {
+      gconstpointer promote =
+        g_ptr_array_index(toplevel->always_promote_attributes, i);
+      if (name == promote)
         return TRUE;
     }
   }

--- a/libgeda/src/geda_object_list.c
+++ b/libgeda/src/geda_object_list.c
@@ -113,7 +113,8 @@ GList *o_glist_copy_all (TOPLEVEL *toplevel,
         o_attrib_attach(toplevel, dst_object,
                         src_object->attached_to->copied_to, FALSE);
         /* handle slot= attribute, it's a special case */
-        if (g_ascii_strncasecmp (dst_object->text->string, "slot=", 5) == 0)
+        if (g_ascii_strncasecmp (geda_text_object_get_string (dst_object),
+                                 "slot=", 5) == 0)
           s_slot_update_object (toplevel, src_object->attached_to->copied_to);
       }
     }

--- a/libgeda/src/geda_text_object.c
+++ b/libgeda/src/geda_text_object.c
@@ -372,11 +372,15 @@ update_disp_string (OBJECT *object)
         }
         break;
     }
+
+    text->name = g_intern_string (name);
+
     /* free the strings allocated by o_attrib_get_name_value */
     g_free(name);
     g_free(value);
   } else {
     text->disp_string = g_strdup (text->string);
+    text->name = NULL;
   }
 }
 
@@ -429,6 +433,7 @@ geda_text_object_new (TOPLEVEL *toplevel,
   text->x = x;
   text->y = y;
   text->angle = angle;
+  text->name = NULL;
 
   new_node->text = text;
 

--- a/libgeda/src/i_vars.c
+++ b/libgeda/src/i_vars.c
@@ -48,7 +48,7 @@ int   default_init_bottom = 90750;
 
 char *default_bitmap_directory = NULL;
 char *default_bus_ripper_symname = NULL;
-GList *default_always_promote_attributes = NULL;
+GPtrArray *default_always_promote_attributes = NULL;
 
 int   default_attribute_promotion = TRUE;
 int   default_promote_invisible = FALSE;
@@ -65,8 +65,6 @@ int   default_make_backup_files = TRUE;
  */
 void i_vars_libgeda_set(TOPLEVEL *toplevel)
 {
-  GList *iter;
-
   toplevel->init_left    = default_init_left;
   toplevel->init_right   = default_init_right;
   toplevel->init_top     = default_init_top;
@@ -79,12 +77,14 @@ void i_vars_libgeda_set(TOPLEVEL *toplevel)
   toplevel->make_backup_files = default_make_backup_files;
 
   /* copy the always_promote_attributes list from the default */
-  g_list_foreach(toplevel->always_promote_attributes, (GFunc) g_free, NULL);
-  g_list_free(toplevel->always_promote_attributes);
-  toplevel->always_promote_attributes = g_list_copy(default_always_promote_attributes);
-  for (iter = toplevel->always_promote_attributes; iter != NULL;
-       iter = g_list_next(iter))
-    iter->data = g_strdup(iter->data);
+  if (toplevel->always_promote_attributes) {
+    g_ptr_array_unref (toplevel->always_promote_attributes);
+    toplevel->always_promote_attributes = NULL;
+  }
+  if (default_always_promote_attributes) {
+    toplevel->always_promote_attributes =
+      g_ptr_array_ref (default_always_promote_attributes);
+  }
 
   /* you cannot free the default* strings here since new windows */
   /* need them */
@@ -103,7 +103,6 @@ void i_vars_libgeda_freenames()
   g_free(default_bitmap_directory);
   g_free(default_bus_ripper_symname);
 
-  g_list_foreach(default_always_promote_attributes, (GFunc) g_free, NULL);
-  g_list_free(default_always_promote_attributes);
+  g_ptr_array_unref (default_always_promote_attributes);
   default_always_promote_attributes = NULL;
 }

--- a/libgeda/src/o_attrib.c
+++ b/libgeda/src/o_attrib.c
@@ -478,28 +478,19 @@ GList *o_attrib_find_floating_attribs (const GList *list)
  */
 OBJECT *o_attrib_find_attrib_by_name (const GList *list, char *name, int count)
 {
-  OBJECT *a_current;
-  const GList *iter;
-  char *found_name;
-  int internal_counter = 0;
+  g_return_val_if_fail (name, NULL);
 
-  for (iter = list; iter != NULL; iter = g_list_next (iter)) {
-    a_current = iter->data;
+  const gchar *needle = g_intern_string (name);
+  int num_found = 0;
 
-    g_return_val_if_fail (a_current->type == OBJ_TEXT, NULL);
+  for (const GList *iter = list; iter; iter = g_list_next (iter)) {
+    OBJECT *attrib = iter->data;
+    g_return_val_if_fail (attrib->type == OBJ_TEXT, NULL);
 
-    if (!o_attrib_get_name_value (a_current, &found_name, NULL))
-      continue;
-
-    if (strcmp (name, found_name) == 0) {
-      if (internal_counter == count) {
-        g_free (found_name);
-        return a_current;
-      }
-      internal_counter++;
+    if ((needle == o_attrib_get_name (attrib)) &&
+        (num_found++ == count)) {
+      return attrib;
     }
-
-    g_free (found_name);
   }
 
   return NULL;

--- a/libgeda/src/o_attrib.c
+++ b/libgeda/src/o_attrib.c
@@ -691,3 +691,15 @@ int o_attrib_is_inherited (OBJECT *attrib)
   return (attrib->attached_to == NULL &&
           attrib->parent != NULL);
 }
+
+/*! \brief Query whether an object is an attribute
+ * \par Function Description
+ * Return #TRUE if \a obj is a text attribute, and #FALSE otherwise.
+ */
+gboolean
+o_attrib_is_attrib (const OBJECT *obj)
+{
+  return (obj &&
+          (obj->type == OBJ_TEXT) &&
+          o_attrib_get_name (obj));
+}

--- a/libgeda/src/o_attrib.c
+++ b/libgeda/src/o_attrib.c
@@ -413,6 +413,22 @@ o_attrib_get_name_value (OBJECT *attrib, gchar **name_ptr, gchar **value_ptr)
                                          name_ptr, value_ptr);
 }
 
+/*! \brief Get the name from an attribute
+ * \par Function Description
+ * Get an interned string for the attribute name of the attribute text
+ * object \a attrib.  If \a attrib is an invalid attribute, returns
+ * NULL.
+ *
+ * \param attrib   An attribute #OBJECT
+ * \return The interned attribute name, or NULL.
+ */
+const gchar *
+o_attrib_get_name (const OBJECT *attrib)
+{
+  g_return_val_if_fail (attrib, 0);
+  g_return_val_if_fail (attrib->type == OBJ_TEXT, 0);
+  return attrib->text->name;
+}
 
 /*! \brief Find all floating attributes in the given object list.
  *  \par Function Description

--- a/libgeda/src/o_attrib.c
+++ b/libgeda/src/o_attrib.c
@@ -452,9 +452,8 @@ GList *o_attrib_find_floating_attribs (const GList *list)
     /* Skip non text objects, attached attributes and text which doesn't
      * constitute a valid attributes (e.g. general text placed on the page)
      */
-    if (o_current->type == OBJ_TEXT &&
-        o_current->attached_to == NULL &&
-        o_attrib_get_name_value (o_current, NULL, NULL)) {
+    if (o_attrib_is_attrib (o_current) &&
+        o_current->attached_to == NULL) {
 
       floating_attributes = g_list_prepend (floating_attributes, o_current);
     }
@@ -656,7 +655,7 @@ GList * o_attrib_return_attribs (OBJECT *object)
       continue;
 
     /* Don't add invalid attributes to the list */
-    if (!o_attrib_get_name_value (a_current, NULL, NULL))
+    if (!o_attrib_is_attrib (a_current))
       continue;
 
     attribs = g_list_prepend (attribs, a_current);

--- a/libgeda/src/o_attrib.c
+++ b/libgeda/src/o_attrib.c
@@ -108,7 +108,8 @@ void o_attrib_attach (TOPLEVEL *toplevel, OBJECT *attrib, OBJECT *object,
 
   /* is the object already part of the list ? */
   if (g_list_find (object->attribs, attrib)) {
-    g_warning (_("Attribute [%s] already attached\n"), attrib->text->string);
+    g_warning (_("Attribute [%s] already attached\n"),
+               geda_text_object_get_string (attrib));
     return;
   }
 
@@ -190,7 +191,7 @@ void o_attrib_print(GList *attributes)
     a_current = a_iter->data;
     printf("Attribute points to: %s\n", a_current->name);
     if (a_current->text) {
-      printf("\tText is: %s\n", a_current->text->string);
+      printf("\tText is: %s\n", geda_text_object_get_string (a_current));
     }
 
     a_iter = g_list_next (a_iter);
@@ -408,7 +409,7 @@ o_attrib_get_name_value (OBJECT *attrib, gchar **name_ptr, gchar **value_ptr)
 {
   g_return_val_if_fail (attrib->type == OBJ_TEXT, FALSE);
 
-  return o_attrib_string_get_name_value (attrib->text->string,
+  return o_attrib_string_get_name_value (geda_text_object_get_string (attrib),
                                          name_ptr, value_ptr);
 }
 

--- a/libgeda/src/scheme_attrib.c
+++ b/libgeda/src/scheme_attrib.c
@@ -73,6 +73,39 @@ SCM_DEFINE (parse_attrib, "%parse-attrib", 1, 0, 0,
   return result;
 }
 
+/*! \brief Parse an attribute text object into a name string.
+ * \par Function Description
+ * Tries to parse the underlying string of the text object \a text_s
+ * as an attribute, to obtain the attribute name.  If successful,
+ * returns the name as a string.  Otherwise, raises an
+ * <tt>attribute-format</tt> error.
+ *
+ * \note Scheme API: Implements the %attrib-name procedure of the
+ * (geda core attrib) module.
+ *
+ * \param text_s text object to parse
+ * \return name, or SCM_BOOL_F.
+ */
+SCM_DEFINE (attrib_name, "%attrib-name", 1, 0, 0,
+            (SCM text_s), "Parse attribute name from text object.")
+{
+  SCM_ASSERT (edascm_is_object_type (text_s, OBJ_TEXT), text_s,
+              SCM_ARG1, s_attrib_name);
+
+  OBJECT *text = edascm_to_object (text_s);
+  const gchar *name = o_attrib_get_name (text);
+
+  if (!name) {
+    scm_error (attribute_format_sym, s_parse_attrib,
+               _("~A is not a valid attribute: invalid string '~A'."),
+               scm_list_2 (text_s,
+                           scm_from_utf8_string (geda_text_object_get_string (text))),
+               SCM_EOL);
+  }
+
+  return scm_from_utf8_string (name);
+}
+
 /*! \brief Get a list of an object's attributes.
  * \par Function Description
  * Retrieves the attributes of the smob \a obj_s as a Scheme list of
@@ -284,7 +317,7 @@ init_module_geda_core_attrib ()
   /* Add them to the module's public definitions. */
   scm_c_export (s_parse_attrib, s_object_attribs, s_attrib_attachment,
                 s_attach_attrib_x, s_detach_attrib_x,
-                s_promotable_attribs,
+                s_promotable_attribs, s_attrib_name,
                 NULL);
 }
 


### PR DESCRIPTION
GLib provides a facility for interning strings: `g_intern_string()`.  Interned strings can be compared by pointer, rather than needing a call to `strcmp()` or `strncmp()`.

This patch modifies the text object struct to hold a cached interned string for the attribute name, if the text is currently a valid attribute.  It then builds on this to provide four optimisations:

- `o_attrib_find_attrib_by_name()` now searches using pointer comparison
- Calls to `o_attrib_get_name_value()` just to check if an object is a valid attribute are replaced with calls to a new `o_attrib_is_attrib()` function, which just checks if there's an interned name in the object
- The "always promote attributes" setting is now based on a `GPtrArray` of interned strings, allowing much faster checks for attribute eligibility for promotion
- The `attrib-name` Scheme API procedure is now implemented in C, avoiding many of the costly operations required by `parse-attrib`