### PR TITLE
Use accessors for setting & retrieving page filename

### DIFF
--- a/gattrib/src/s_toplevel.c
+++ b/gattrib/src/s_toplevel.c
@@ -64,7 +64,7 @@ int s_toplevel_read_page(TOPLEVEL *toplevel, char *filename)
   GError *err = NULL;
     
   /* Set the new filename */
-  toplevel->page_current->page_filename = g_strdup(filename);
+  s_page_set_filename (toplevel->page_current, filename);
   
   /* read in and fill out toplevel using f_open and its callees */
   file_return_code = f_open (toplevel, toplevel->page_current, filename, &err);

--- a/gattrib/src/x_fileselect.c
+++ b/gattrib/src/x_fileselect.c
@@ -303,9 +303,8 @@ x_fileselect_save (void)
         f_save (pr_current, pr_current->page_current, filename, NULL)) {
       s_log_message (_("Saved As [%s]\n"), filename);
 
-      /* replace page filename with new one, do not free filename */
-      g_free (pr_current->page_current->page_filename);
-      pr_current->page_current->page_filename = filename;
+      /* replace page filename with new one */
+      s_page_set_filename (pr_current->page_current, filename);
 
       /* reset the changed flag of current page*/
       pr_current->page_current->CHANGED = 0;
@@ -313,11 +312,10 @@ x_fileselect_save (void)
     } else {
       /* report error in log and status bar */
       s_log_message (_("Could NOT save [%s]\n"),
-                     pr_current->page_current->page_filename);
-
-      g_free (filename);
+                     s_page_get_filename (pr_current->page_current));
 
     }
+    g_free (filename);
   }
   gtk_widget_destroy (dialog);
 

--- a/gschem/src/gschem_close_confirmation_dialog.c
+++ b/gschem/src/gschem_close_confirmation_dialog.c
@@ -222,8 +222,8 @@ get_page_name (GtkTreeModel *model, GtkTreeIter *piter)
   gtk_tree_model_get (model, &iter,
                       COLUMN_PAGE, &page,
                       -1);
-  g_assert (page != NULL && page->page_filename != NULL);
-  return g_path_get_basename (page->page_filename);
+  g_assert (page != NULL);
+  return g_path_get_basename (s_page_get_filename (page));
 }
 
 /*! \brief Sets the contents of the name cell in the treeview of dialog.

--- a/gschem/src/gschem_find_text_state.c
+++ b/gschem/src/gschem_find_text_state.c
@@ -248,7 +248,7 @@ assign_store (GschemFindTextState *state, GSList *objects)
 
     gtk_list_store_append (state->store, &tree_iter);
 
-    basename = g_path_get_basename (object->page->page_filename);
+    basename = g_path_get_basename (s_page_get_filename (object->page));
 
     gtk_list_store_set (state->store,
                         &tree_iter,

--- a/gschem/src/gschem_preview.c
+++ b/gschem/src/gschem_preview.c
@@ -74,14 +74,14 @@ gschem_preview_new ()
 
 /*! \brief get the filename for the current page
  */
-static char*
+static const char*
 preview_get_filename (GschemPreview *preview)
 {
   PAGE *page = gschem_page_view_get_page (GSCHEM_PAGE_VIEW (preview));
 
   g_return_val_if_fail (page != NULL, "");
 
-  return page->page_filename;
+  return s_page_get_filename (page);
 }
 
 

--- a/gschem/src/i_callbacks.c
+++ b/gschem/src/i_callbacks.c
@@ -71,7 +71,7 @@ DEFINE_I_CALLBACK(file_new)
   g_return_if_fail (page != NULL);
 
   x_window_set_current_page (w_current, page);
-  s_log_message (_("New page created [%s]\n"), page->page_filename);
+  s_log_message (_("New page created [%s]\n"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -105,7 +105,7 @@ DEFINE_I_CALLBACK(file_new_window)
 
   x_window_set_current_page (w_current, page);
 
-  s_log_message (_("New Window created [%s]\n"), page->page_filename);
+  s_log_message (_("New Window created [%s]\n"), s_page_get_filename (page));
 }
 
 /*! \todo Finish function documentation!!!
@@ -181,12 +181,12 @@ DEFINE_I_CALLBACK(file_save)
 
   /*! \bug This is a dreadful way of figuring out whether a page is
    *  newly-created or not. */
-  cfg = eda_config_get_context_for_path (page->page_filename);
+  cfg = eda_config_get_context_for_path (s_page_get_filename (page));
   untitled_name = eda_config_get_string (cfg, "gschem", "default-filename", NULL);
-  if (strstr(page->page_filename, untitled_name)) {
+  if (strstr(s_page_get_filename (page), untitled_name)) {
     x_fileselect_save (w_current);
   } else {
-    x_window_save_page (w_current, page, page->page_filename);
+    x_window_save_page (w_current, page, s_page_get_filename (page));
   }
   g_free (untitled_name);
 }
@@ -1532,7 +1532,7 @@ DEFINE_I_CALLBACK(page_revert)
     return;
 
   /* save this for later */
-  filename = g_strdup (page_current->page_filename);
+  filename = g_strdup (s_page_get_filename (page_current));
   page_control = page_current->page_control;
   up = page_current->up;
 

--- a/gschem/src/o_misc.c
+++ b/gschem/src/o_misc.c
@@ -535,10 +535,10 @@ void o_autosave_backups(GschemToplevel *w_current)
       gschem_toplevel_page_changed (w_current);
 
       /* Get the real filename and file permissions */
-      real_filename = follow_symlinks (p_current->page_filename, NULL);
+      real_filename = follow_symlinks (s_page_get_filename (p_current), NULL);
 
       if (real_filename == NULL) {
-        s_log_message (_("o_autosave_backups: Can't get the real filename of %s."), p_current->page_filename);
+        s_log_message (_("o_autosave_backups: Can't get the real filename of %s."), s_page_get_filename (p_current));
       } else {
         /* Get the directory in which the real filename lives */
         dirname = g_path_get_dirname (real_filename);

--- a/gschem/src/o_undo.c
+++ b/gschem/src/o_undo.c
@@ -377,7 +377,7 @@ o_undo_callback (GschemToplevel *w_current, PAGE *page, int type)
   }
 
   /* save filename */
-  save_filename = g_strdup (page->page_filename);
+  save_filename = g_strdup (s_page_get_filename (page));
 
   /* save structure so it's not nuked */
   save_bottom = page->undo_bottom;
@@ -448,8 +448,8 @@ o_undo_callback (GschemToplevel *w_current, PAGE *page, int type)
   do_logging = save_logging;
 
   /* set filename right */
-  g_free(page->page_filename);
-  page->page_filename = save_filename;
+  s_page_set_filename (page, save_filename);
+  g_free(save_filename);
 
   /* final redraw */
   x_pagesel_update (w_current);

--- a/gschem/src/x_compselect.c
+++ b/gschem/src/x_compselect.c
@@ -476,7 +476,7 @@ update_attributes_model (Compselect *compselect, TOPLEVEL *preview_toplevel)
   o_attrlist = o_attrib_find_floating_attribs (
                               s_page_objects (preview_toplevel->page_current));
 
-  cfg = eda_config_get_context_for_path (preview_toplevel->page_current->page_filename);
+  cfg = eda_config_get_context_for_path (s_page_get_filename (preview_toplevel->page_current));
   filter_list = eda_config_get_string_list (cfg, "gschem.library",
                                             "component-attributes", &n, NULL);
 
@@ -852,7 +852,7 @@ create_lib_tree_model (Compselect *compselect)
   GtkTreeStore *store;
   GList *srchead, *srclist;
   PAGE *page = GSCHEM_DIALOG(compselect)->w_current->toplevel->page_current;
-  EdaConfig *cfg = eda_config_get_context_for_path (page->page_filename);
+  EdaConfig *cfg = eda_config_get_context_for_path (s_page_get_filename (page));
   gboolean sort = eda_config_get_boolean (cfg, "gschem.library", "sort", NULL);
 
   store = (GtkTreeStore*)gtk_tree_store_new (3, G_TYPE_POINTER,

--- a/gschem/src/x_fileselect.c
+++ b/gschem/src/x_fileselect.c
@@ -258,11 +258,10 @@ x_fileselect_save (GschemToplevel *w_current)
   /* add file filters to dialog */
   x_fileselect_setup_filechooser_filters (GTK_FILE_CHOOSER (dialog));
   /* set the current filename or directory name if new document */
-  if ((toplevel->page_current->page_filename != NULL) &&
-      g_file_test (toplevel->page_current->page_filename,
+  if (g_file_test (s_page_get_filename (toplevel->page_current),
                    G_FILE_TEST_EXISTS)) {
     gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog),
-                                   toplevel->page_current->page_filename);
+                                   s_page_get_filename (toplevel->page_current));
   } else {
     gchar *cwd = g_get_current_dir ();
     /* force save in current working dir */

--- a/gschem/src/x_image.c
+++ b/gschem/src/x_image.c
@@ -161,7 +161,7 @@ static void x_image_update_dialog_filename(GtkComboBox *combo,
   TOPLEVEL *toplevel = gschem_toplevel_get_toplevel (w_current);
   char* image_type_descr = NULL;
   char *image_type = NULL;
-  char *old_image_filename = NULL;
+  const char *old_image_filename = NULL;
   char *file_basename = NULL;
   char *file_name = NULL ;
   char *new_image_filename = NULL;
@@ -178,7 +178,7 @@ static void x_image_update_dialog_filename(GtkComboBox *combo,
   /* Get the previous file name. If none, revert to the page filename */
   old_image_filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(file_chooser));
   if (!old_image_filename) {
-    old_image_filename = toplevel->page_current->page_filename;
+    old_image_filename = s_page_get_filename (toplevel->page_current);
   }
 
   /* Get the file name, without extension */

--- a/gschem/src/x_pagesel.c
+++ b/gschem/src/x_pagesel.c
@@ -99,7 +99,8 @@ void x_pagesel_update (GschemToplevel *w_current)
     return;
   }
 
-  i_set_filename (w_current, page->page_filename, page->CHANGED ? "* " : "");
+  i_set_filename (w_current, s_page_get_filename (page),
+                  page->CHANGED ? "* " : "");
 }
 
 /*! \brief Callback for page manager response.
@@ -511,7 +512,7 @@ static void add_page (GtkTreeModel *model, GtkTreeIter *parent,
   gtk_tree_store_set (GTK_TREE_STORE (model),
                       &iter,
                       COLUMN_PAGE, page,
-                      COLUMN_NAME, page->page_filename,
+                      COLUMN_NAME, s_page_get_filename (page),
                       COLUMN_CHANGED, page->CHANGED,
                       -1);
 

--- a/gschem/src/x_print.c
+++ b/gschem/src/x_print.c
@@ -72,7 +72,7 @@ x_print_default_page_setup (TOPLEVEL *toplevel, PAGE *page)
   gchar *paper, *orientation;
 
   /* Get configuration values */
-  cfg =         eda_config_get_context_for_path (page->page_filename);
+  cfg =         eda_config_get_context_for_path (s_page_get_filename (page));
   paper =       eda_config_get_string (cfg, CFG_GROUP_PRINTING,
                                        CFG_KEY_PRINTING_PAPER, NULL);
   orientation = eda_config_get_string (cfg, CFG_GROUP_PRINTING,
@@ -242,7 +242,7 @@ draw_page__print_operation (GtkPrintOperation *print,
   height = gtk_print_context_get_height (context);
 
   /* Find out if colour printing is enabled */
-  cfg = eda_config_get_context_for_path (page->page_filename);
+  cfg = eda_config_get_context_for_path (s_page_get_filename (page));
   is_color = !eda_config_get_boolean (cfg, CFG_GROUP_PRINTING,
                                       CFG_KEY_PRINTING_MONOCHROME, NULL);
 
@@ -292,7 +292,7 @@ x_print_export_pdf_page (GschemToplevel *w_current,
   height = gtk_page_setup_get_page_height (setup, GTK_UNIT_POINTS);
 
   /* Find out if colour printing is enabled */
-  cfg = eda_config_get_context_for_path (page->page_filename);
+  cfg = eda_config_get_context_for_path (s_page_get_filename (page));
   is_color = !eda_config_get_boolean (cfg, CFG_GROUP_PRINTING,
                                       CFG_KEY_PRINTING_MONOCHROME, NULL);
 

--- a/gschem/src/x_window.c
+++ b/gschem/src/x_window.c
@@ -941,7 +941,7 @@ x_window_open_page (GschemToplevel *w_current, const gchar *filename)
   } else {
     if (!quiet_mode)
       s_log_message (_("New file [%s]\n"),
-                     toplevel->page_current->page_filename);
+                     s_page_get_filename (toplevel->page_current));
 
     g_run_hook_page (w_current, "%new-page-hook", toplevel->page_current);
   }
@@ -1036,9 +1036,8 @@ x_window_save_page (GschemToplevel *w_current, PAGE *page, const gchar *filename
   } else {
     /* successful save of page to file, update page... */
     /* change page name if necessary and prepare log message */
-    if (g_ascii_strcasecmp (page->page_filename, filename) != 0) {
-      g_free (page->page_filename);
-      page->page_filename = g_strdup (filename);
+    if (g_ascii_strcasecmp (s_page_get_filename (page), filename) != 0) {
+      s_page_set_filename (page, filename);
 
       log_msg = _("Saved as [%s]\n");
     } else {
@@ -1116,7 +1115,7 @@ x_window_close_page (GschemToplevel *w_current, PAGE *page)
 
   s_log_message (page->CHANGED ?
                  _("Discarding page [%s]\n") : _("Closing [%s]\n"),
-                 page->page_filename);
+                 s_page_get_filename (page));
   /* remove page from toplevel list of page and free */
   s_page_delete (toplevel, page);
   gschem_toplevel_page_changed (w_current);

--- a/gsymcheck/src/gsymcheck.c
+++ b/gsymcheck/src/gsymcheck.c
@@ -101,7 +101,7 @@ main_prog(void *closure, int argc, char *argv[])
 
     if (!f_open (pr_current,
                  pr_current->page_current,
-                 pr_current->page_current->page_filename,
+                 s_page_get_filename (pr_current->page_current),
                  &err)) {
       /* Not being able to load a file is apparently a fatal error */
       logging_dest = STDOUT_TTY;

--- a/gsymcheck/src/s_check.c
+++ b/gsymcheck/src/s_check.c
@@ -74,7 +74,7 @@ s_check_symbol (TOPLEVEL *pr_current, PAGE *p_current, const GList *obj_list)
   s_symcheck = s_symstruct_init();
   
   if (!quiet_mode) {
-    s_log_message(_("Checking: %s\n"), p_current->page_filename);
+    s_log_message(_("Checking: %s\n"), s_page_get_filename (p_current));
   }
   
   /* overal symbol structure test */

--- a/libgeda/include/libgeda/geda_page.h
+++ b/libgeda/include/libgeda/geda_page.h
@@ -1,7 +1,7 @@
 /* gEDA - GPL Electronic Design Automation
  * libgeda - gEDA's library
  * Copyright (C) 1998-2010 Ales Hvezda
- * Copyright (C) 1998-2010 gEDA Contributors (see ChangeLog for details)
+ * Copyright (C) 1998-2017 gEDA Contributors (see ChangeLog for details)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,11 @@ struct st_page
   OBJECT *object_lastplace; /* the last found item */
   GList *connectible_list;  /* connectible page objects */
 
-  char *page_filename;
+  /* The page filename. You must access this field only via the
+   * accessor functions s_page_set_filename() and
+   * s_page_get_filename() */
+  char *_filename;
+
   int CHANGED;			/* changed flag */
 
   /* Undo/Redo Stacks and pointers */
@@ -129,3 +133,7 @@ s_page_objects_in_region (TOPLEVEL *toplevel, PAGE *page, int min_x, int min_y, 
 
 GList*
 s_page_objects_in_regions (TOPLEVEL *toplevel, PAGE *page, BOX *rects, int n_rects);
+
+const gchar *s_page_get_filename (const PAGE *page);
+
+void s_page_set_filename (PAGE *page, const char *filename);

--- a/libgeda/src/f_basic.c
+++ b/libgeda/src/f_basic.c
@@ -215,8 +215,7 @@ int f_open_flags(TOPLEVEL *toplevel, PAGE *page,
   }
 
   /* write full, absolute filename into page->page_filename */
-  g_free(page->page_filename);
-  page->page_filename = g_strdup(full_filename);
+  s_page_set_filename (page, full_filename);
 
   /* Before we open the page, let's load the corresponding gafrc. */
   /* First cd into file's directory. */

--- a/libgeda/src/s_hierarchy.c
+++ b/libgeda/src/s_hierarchy.c
@@ -111,14 +111,14 @@ s_hierarchy_down_schematic_single(TOPLEVEL *toplevel, const gchar *filename,
 
       found = s_page_new (toplevel, string);
 
-      f_open (toplevel, found, found->page_filename, NULL);
+      f_open (toplevel, found, s_page_get_filename (found), NULL);
     }
     break;
 
   case HIERARCHY_FORCE_LOAD:
     {
       found = s_page_new (toplevel, string);
-      f_open (toplevel, found, found->page_filename, NULL);
+      f_open (toplevel, found, s_page_get_filename (found), NULL);
     }
     break;
 
@@ -170,7 +170,7 @@ s_hierarchy_down_symbol (TOPLEVEL *toplevel, const CLibSymbol *symbol,
 
   s_page_goto (toplevel, page);
 
-  f_open(toplevel, page, page->page_filename, NULL);
+  f_open(toplevel, page, s_page_get_filename (page), NULL);
 
   page->up = parent->pid;
   page_control_counter++;
@@ -248,7 +248,7 @@ s_hierarchy_load_subpage (PAGE *page, const char *filename, GError **error)
       int success;
 
       subpage = s_page_new (page->toplevel, string);
-      success = f_open (page->toplevel, subpage, subpage->page_filename, error);
+      success = f_open (page->toplevel, subpage, s_page_get_filename (subpage), error);
 
       if (success) {
         subpage->page_control = ++page_control_counter;
@@ -371,7 +371,7 @@ gint
 s_hierarchy_print_page (PAGE *p_current, void * data)
 {
   printf("pagefilename: %s pageid: %d\n",
-         p_current->page_filename, p_current->pid);
+         s_page_get_filename (p_current), p_current->pid);
   return 0;
 }
 

--- a/libgeda/src/scheme_page.c
+++ b/libgeda/src/scheme_page.c
@@ -133,7 +133,7 @@ SCM_DEFINE (page_filename, "%page-filename", 1, 0, 0,
 
 
   page = edascm_to_page (page_s);
-  return scm_from_utf8_string (page->page_filename);
+  return scm_from_utf8_string (s_page_get_filename(page));
 }
 
 /*! \brief Change the filename associated with a page.
@@ -157,10 +157,7 @@ SCM_DEFINE (set_page_filename_x, "%set-page-filename!", 2, 0, 0,
 
   PAGE *page = edascm_to_page (page_s);
   char *new_fn = scm_to_utf8_string (filename_s);
-  if (page->page_filename != NULL) {
-    g_free (page->page_filename);
-  }
-  page->page_filename = g_strdup (new_fn);
+  s_page_set_filename (page, new_fn);
   free (new_fn);
 
   return page_s;
@@ -430,7 +427,7 @@ SCM_DEFINE (string_to_page, "%string->page", 2, 0, 0,
   GError * err = NULL;
   char *str = scm_to_utf8_stringn (str_s, &len);
   GList *objects = o_read_buffer (toplevel, NULL, str, len,
-                                  page->page_filename, &err);
+                                  s_page_get_filename(page), &err);
   free (str);
 
   if (err) {

--- a/utils/gschlas/gschlas.c
+++ b/utils/gschlas/gschlas.c
@@ -112,7 +112,7 @@ main_prog(void *closure, int argc, char *argv[])
     s_page_goto (pr_current, s_page_new (pr_current, filename));
 
     if (!f_open (pr_current, pr_current->page_current,
-                 pr_current->page_current->page_filename, &err)) {
+                 s_page_get_filename (pr_current->page_current), &err)) {
       /* Not being able to load a file is apparently a fatal error */
       g_warning ("%s\n", err->message);
       g_error_free (err);


### PR DESCRIPTION
Setting page filename via `s_page_set_filename()` will allow libgeda
to perform actions when a page filename is set, such as updating a
configuration context pointer or notifying callback functions.

Retrieving page filename via `s_page_get_filename()` will allow the
page structure to use a different backing store for the file
information, such as a `GFile`.