### PR TITLE
Fix valgrind-detected defects due to weak reference misuse

### DIFF
--- a/gschem/include/gschem_page_view.h
+++ b/gschem/include/gschem_page_view.h
@@ -53,8 +53,9 @@ struct _GschemPageView
   int pan_y;
   int throttle;
 
-  PAGE *page;
   /*< private >*/
+  PAGE *_page;
+
   GHashTable *_geometry_cache;
 };
 

--- a/gschem/include/gschem_page_view.h
+++ b/gschem/include/gschem_page_view.h
@@ -46,8 +46,6 @@ struct _GschemPageView
   GtkAdjustment *hadjustment;
   GtkAdjustment *vadjustment;
 
-  GHashTable *geometry_table;
-
   gboolean configured;
 
   gboolean doing_pan;  /* mouse pan status flag */
@@ -56,6 +54,8 @@ struct _GschemPageView
   int throttle;
 
   PAGE *page;
+  /*< private >*/
+  GHashTable *_geometry_cache;
 };
 
 

--- a/gschem/src/gschem_page_view.c
+++ b/gschem/src/gschem_page_view.c
@@ -385,6 +385,11 @@ gschem_page_view_get_page_geometry (GschemPageView *view)
     return NULL;
   }
 
+  /* If there's no window yet, defer geometry calculation until
+   * later. */
+  if (!GDK_IS_DRAWABLE (GTK_WIDGET (view)->window))
+    return NULL;
+
   geometry = geometry_cache_lookup (view, page);
 
   /* \todo The following line is deprecated in GDK 2.24 */

--- a/gschem/src/gschem_preview.c
+++ b/gschem/src/gschem_preview.c
@@ -357,7 +357,10 @@ preview_init (GschemPreview *preview)
   preview->active   = FALSE;
   preview->filename = NULL;
   preview->buffer   = NULL;
-  GSCHEM_PAGE_VIEW (preview)->page = s_page_new (preview->preview_w_current->toplevel, "preview");
+
+  gschem_page_view_set_page (GSCHEM_PAGE_VIEW (preview),
+                             s_page_new (preview->preview_w_current->toplevel,
+                                         "preview"));
 
   gtk_widget_set_events (GTK_WIDGET (preview),
                          GDK_EXPOSURE_MASK |

--- a/libgeda/include/prototype_priv.h
+++ b/libgeda/include/prototype_priv.h
@@ -57,7 +57,7 @@ gchar* s_encoding_base64_encode (gchar* src, guint srclen, guint* dstlenp, gbool
 gchar* s_encoding_base64_decode (gchar* src, guint srclen, guint* dstlenp);
 
 /* s_weakref.c */
-void s_weakref_notify (void *dead_ptr, GList *weak_refs);
+GList *s_weakref_notify (void *dead_ptr, GList *weak_refs);
 GList *s_weakref_add (GList *weak_refs, void (*notify_func)(void *, void *), void *user_data);
 GList *s_weakref_remove (GList *weak_refs, void (*notify_func)(void *, void *), void *user_data);
 GList *s_weakref_add_ptr (GList *weak_refs, void **weak_pointer_loc);

--- a/libgeda/src/geda_object.c
+++ b/libgeda/src/geda_object.c
@@ -311,7 +311,7 @@ s_delete_object(TOPLEVEL *toplevel, OBJECT *o_current)
 
     o_attrib_detach_all (toplevel, o_current);
 
-    s_weakref_notify (o_current, o_current->weak_refs);
+    o_current->weak_refs = s_weakref_notify (o_current, o_current->weak_refs);
 
     g_free(o_current);	/* assuming it is not null */
 

--- a/libgeda/src/geda_page.c
+++ b/libgeda/src/geda_page.c
@@ -243,7 +243,7 @@ void s_page_delete (TOPLEVEL *toplevel, PAGE *page)
 
   geda_list_remove( toplevel->pages, page );
 
-  s_weakref_notify (page, page->weak_refs);
+  page->weak_refs = s_weakref_notify (page, page->weak_refs);
 
   g_free (page);
 

--- a/libgeda/src/geda_toplevel.c
+++ b/libgeda/src/geda_toplevel.c
@@ -138,7 +138,7 @@ void s_toplevel_delete (TOPLEVEL *toplevel)
   }
   g_list_free (toplevel->change_notify_funcs);
 
-  s_weakref_notify (toplevel, toplevel->weak_refs);
+  toplevel->weak_refs = s_weakref_notify (toplevel, toplevel->weak_refs);
 
   g_free (toplevel);
 

--- a/libgeda/src/s_weakref.c
+++ b/libgeda/src/s_weakref.c
@@ -43,8 +43,9 @@ struct WeakRef
  *
  * \param [in] dead_ptr       Pointer to structure being destroyed.
  * \param [in,out] weak_refs  List of registered weak references.
+ * \return new head of \a weak_refs list.
  */
-void
+GList *
 s_weakref_notify (void *dead_ptr, GList *weak_refs)
 {
   GList *iter;
@@ -57,6 +58,7 @@ s_weakref_notify (void *dead_ptr, GList *weak_refs)
     g_free (entry);
   }
   g_list_free (weak_refs);
+  return NULL;
 }
 
 /*! \brief Add a weak reference watcher to a weak ref list.


### PR DESCRIPTION
This fixes several weak reference lifetime errors in `gschem`, correcting a large number of use-after-free problems detected by `valgrind`.